### PR TITLE
Refactor Linux build workflow and add caching

### DIFF
--- a/.github/workflows/Linux-Build.yml
+++ b/.github/workflows/Linux-Build.yml
@@ -1,8 +1,6 @@
 name: Builds on Linux (Ubuntu)
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -12,11 +10,10 @@ jobs:
 
     strategy:
       fail-fast: false
-
       matrix:
         os: [ubuntu-24.04]
         build_type: [Release, Debug]
-        c_compiler: [gcc, clang, cl]
+        c_compiler: [gcc, clang]
         include:
           - os: ubuntu-24.04
             c_compiler: gcc
@@ -24,18 +21,36 @@ jobs:
           - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
-        exclude:
-          - os: ubuntu-24.04
-            c_compiler: cl
-          - os: macos-14
-            c_compiler: gcc
-          - os: macos-14
-            c_compiler: cl
+
+
 
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ubuntu-${{  matrix.cpp_compiler }}-${{ matrix.build_type }}
+        max-size: 500M
+
+    - name: Cache Vulkan SDK
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/VULKAN_SDK
+          ~/.vulkan
+        key: vulkan-ubuntu-1.4.304.1
+        restore-keys: |
+          vulkan-ubuntu-
+
+    # Cache APT packages
+    - name: Cache APT packages
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: ninja-build libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev
+        version: 1.0
+
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
@@ -53,6 +68,7 @@ jobs:
           libxi-dev \
           libgl1-mesa-dev \
           libglu1-mesa-dev
+
     - name: Prepare Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
@@ -68,23 +84,35 @@ jobs:
         
     - name: Use cmake
       run: cmake --version
+
+    - name: Cache CMake dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/build/_deps
+        key: cmake-deps-ubuntu-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          cmake-deps-ubuntu-
       
     - name: Set reusable strings
       id: strings
       shell: bash
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-    - name: Configure CMake with Ninja
+  
+    - name: Configure CMake with Ninja and ccache
       run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        cmake -B build
         -G Ninja
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -S ${{ github.workspace }}
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+  
     - name: Build
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      run: cmake --build build --config ${{ matrix.build_type }} --parallel $(nproc)
 
     - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      run: ctest --build-config ${{ matrix.build_type }}
+      working-directory: build
+      run: ctest --build-config ${{ matrix.build_type }} --output-on-failure


### PR DESCRIPTION
Updated the Linux build workflow to remove the 'cl' compiler and added caching for CMake dependencies and APT packages.